### PR TITLE
SEM1: This makes queryIndexOfType easier to understand

### DIFF
--- a/src/main/java/dk/sdu/se_f22/searchmodule/infrastructure/SearchModuleImpl.java
+++ b/src/main/java/dk/sdu/se_f22/searchmodule/infrastructure/SearchModuleImpl.java
@@ -5,11 +5,9 @@ import dk.sdu.se_f22.searchmodule.infrastructure.interfaces.SearchModule;
 import dk.sdu.se_f22.sharedlibrary.models.*;
 import dk.sdu.se_f22.sharedlibrary.SearchHits;
 
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.*;
-import java.util.function.BiFunction;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 
 public class SearchModuleImpl implements SearchModule {
@@ -29,17 +27,43 @@ public class SearchModuleImpl implements SearchModule {
 
     @SuppressWarnings("unchecked")
     public <T> List<T> queryIndexOfType(Class<T> clazz, List<String> tokens) {
-        BiFunction<Type, String, Boolean> interfaceGenericEquals = (Type genericInterface, String target) -> {
-            Pattern pattern = Pattern.compile("<([^>]+)>");
-            Matcher matcher = pattern.matcher(genericInterface.getTypeName());
-            return matcher.find() && Objects.equals(matcher.group(1), target);
-        };
+        // We need to find the indexing module for the specified page type (i.e. content, brand, product or something else)
+        for (var indexingModule : indexingModules) {
+            // Using reflection we can get the generic type parameter for the indexing module,
+            // meaning the class specified between the angle brackets.
 
-        for (var index : indexingModules) {
-            for (Type genericInterface : index.getClass().getGenericInterfaces()) {
-                if (interfaceGenericEquals.apply(genericInterface, clazz.getTypeName())) {
-                    return (List<T>) index.queryIndex(tokens);
-                }
+            // Here we just get a list of all the parameterized interfaces
+            // this indexing module implements.
+            List<Type> moduleInterfaces = Arrays.stream(
+                    indexingModule.getClass().getGenericInterfaces()
+            ).toList();
+
+            // Since we need to find the type parameter, we down-cast to a ParameterizedType list
+            List<ParameterizedType> parameterizedModuleInterfaces = moduleInterfaces
+                    .stream()
+                    .map(ParameterizedType.class::cast)
+                    .toList();
+
+            // Now we can extract the type arguments for the interfaces of the indexing module
+            List<Type[]> interfaceTypeParameters = parameterizedModuleInterfaces
+                    .stream()
+                    .map(ParameterizedType::getActualTypeArguments)
+                    .toList();
+
+            // We flatten this list, to make searching for matches easier
+            List<Type> flattenedInterfaceTypeParameters = interfaceTypeParameters.stream()
+                    .map(Arrays::asList) // Convert Type[] to List<Type>
+                    .flatMap(List::stream) // Merge all the lists together
+                    .toList(); // Collect
+
+            // Now we just need to match the given class against the type arguments
+            boolean foundMatchingTypeParameter = flattenedInterfaceTypeParameters
+                    .stream()
+                    .anyMatch(t -> Objects.equals(t.getTypeName(), clazz.getTypeName()));
+
+            // This indexing module is the one matching the given class, so we query that
+            if(foundMatchingTypeParameter) {
+                return (List<T>) indexingModule.queryIndex(tokens);
             }
         }
 


### PR DESCRIPTION
The current version of this method is quite a mess, so i searched for a better solution and found that you can cast `Type` to a `ParameterizedType` and use `getActualTypeArguments` to get the class between the angle brackets instead of using a regex. I also split the code up and added comments to make it easier to understand the code. 