### PR TITLE
SEM1: Switch indexing module lookup to use map

### DIFF
--- a/src/main/java/dk/sdu/se_f22/searchmodule/infrastructure/SearchModuleImpl.java
+++ b/src/main/java/dk/sdu/se_f22/searchmodule/infrastructure/SearchModuleImpl.java
@@ -3,30 +3,45 @@ package dk.sdu.se_f22.searchmodule.infrastructure;
 import dk.sdu.se_f22.searchmodule.infrastructure.interfaces.Filterable;
 import dk.sdu.se_f22.searchmodule.infrastructure.interfaces.IndexingModule;
 import dk.sdu.se_f22.searchmodule.infrastructure.interfaces.SearchModule;
-import dk.sdu.se_f22.sharedlibrary.models.*;
 import dk.sdu.se_f22.sharedlibrary.SearchHits;
+import dk.sdu.se_f22.sharedlibrary.db.LoggingProvider;
+import dk.sdu.se_f22.sharedlibrary.models.Brand;
+import dk.sdu.se_f22.sharedlibrary.models.Product;
+import org.apache.logging.log4j.Logger;
 
 import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.*;
 
 
 public class SearchModuleImpl implements SearchModule {
+    private static final Logger logger = LoggingProvider.getLogger(SearchModuleImpl.class);
     private final Set<Filterable> filteringModules;
-    private final Set<IndexingModule<?>> indexingModules;
+    private final Map<Class<?>, IndexingModule<?>> indexingModules;
     private DelimiterSettings delimiterSettings = new DelimiterSettings();
 
     public SearchModuleImpl() {
-        this.indexingModules = new HashSet<>();
+        this.indexingModules = new HashMap<>();
         this.filteringModules = new HashSet<>();
     }
 
     public <T extends IndexingModule<?>> void addIndexingModule(T index) {
-        indexingModules.add(index);
+        // Get parameterized type i.e. the thing between the angle brackets
+        // Example, here the found class would be Foo:
+        //      class SomeIndexingModule implements IndexingModule<Foo>
+        Class<?> indexDataType = Arrays.stream(index.getClass().getGenericInterfaces())
+                .map(ParameterizedType.class::cast)
+                .map(ParameterizedType::getActualTypeArguments)
+                .map(Arrays::asList)
+                .flatMap(List::stream)
+                .map(Class.class::cast)
+                .findFirst()
+                .orElseThrow();
+
+        indexingModules.put(indexDataType, index);
     }
 
-    public <T extends IndexingModule<?>> void removeIndexingModule(T index) {
-        indexingModules.remove(index);
+    public void removeIndexingModule(Class<?> clazz) {
+        indexingModules.remove(clazz);
     }
 
     public void addFilteringModule(Filterable filteringModule) {
@@ -46,47 +61,14 @@ public class SearchModuleImpl implements SearchModule {
 
     @SuppressWarnings("unchecked")
     public <T> List<T> queryIndexOfType(Class<T> clazz, List<String> tokens) {
-        // We need to find the indexing module for the specified page type (i.e. content, brand, product or something else)
-        for (var indexingModule : indexingModules) {
-            // Using reflection we can get the generic type parameter for the indexing module,
-            // meaning the class specified between the angle brackets.
+        var module = indexingModules.get(clazz);
 
-            // Here we just get a list of all the parameterized interfaces
-            // this indexing module implements.
-            List<Type> moduleInterfaces = Arrays.stream(
-                    indexingModule.getClass().getGenericInterfaces()
-            ).toList();
-
-            // Since we need to find the type parameter, we down-cast to a ParameterizedType list
-            List<ParameterizedType> parameterizedModuleInterfaces = moduleInterfaces
-                    .stream()
-                    .map(ParameterizedType.class::cast)
-                    .toList();
-
-            // Now we can extract the type arguments for the interfaces of the indexing module
-            List<Type[]> interfaceTypeParameters = parameterizedModuleInterfaces
-                    .stream()
-                    .map(ParameterizedType::getActualTypeArguments)
-                    .toList();
-
-            // We flatten this list, to make searching for matches easier
-            List<Type> flattenedInterfaceTypeParameters = interfaceTypeParameters.stream()
-                    .map(Arrays::asList) // Convert Type[] to List<Type>
-                    .flatMap(List::stream) // Merge all the lists together
-                    .toList(); // Collect
-
-            // Now we just need to match the given class against the type arguments
-            boolean foundMatchingTypeParameter = flattenedInterfaceTypeParameters
-                    .stream()
-                    .anyMatch(t -> Objects.equals(t.getTypeName(), clazz.getTypeName()));
-
-            // This indexing module is the one matching the given class, so we query that
-            if(foundMatchingTypeParameter) {
-                return (List<T>) indexingModule.queryIndex(tokens);
-            }
+        if(module == null) {
+            logger.warn("Could not find indexing module: " + clazz.getName());
+            return new ArrayList<>();
         }
 
-        throw new NoSuchElementException();
+        return (List<T>) module.queryIndex(tokens);
     }
 
     @Override

--- a/src/test/java/dk/sdu/se_f22/searchmodule/infrastructure/TestSearchModule.java
+++ b/src/test/java/dk/sdu/se_f22/searchmodule/infrastructure/TestSearchModule.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestSearchModule {
     private SearchModule searchModule;
@@ -75,17 +76,17 @@ public class TestSearchModule {
                 List.of(new MockIndexingData("Foo"), new MockIndexingData("Foo")).toArray()
         );
 
-        // Test throwing
-        assertThrows(
-                NoSuchElementException.class,
-                () -> searchModule.queryIndexOfType(String.class, List.of(""))
+        // Test non-existing module for datatype
+        assertEquals(
+                0,
+                searchModule.queryIndexOfType(String.class, List.of("")).size()
         );
 
         // Test removal
-        searchModule.removeIndexingModule(indexingModule);
-        assertThrows(
-                NoSuchElementException.class,
-                () -> searchModule.queryIndexOfType(MockIndexingData.class, List.of(""))
+        searchModule.removeIndexingModule(MockIndexingData.class);
+        assertEquals(
+                0,
+                searchModule.queryIndexOfType(MockIndexingData.class, List.of("")).size()
         );
     }
 


### PR DESCRIPTION
This moves the reflection code away from the query method and into the method for adding indexing modules. This should both make the logic easier to follow, and since the reflection code is only run once per indexing module instead of 3 times per search, it should also be a lot faster.

