### PR TITLE
Force UTC on timefilter

### DIFF
--- a/src/main/java/dk/sdu/se_f22/sortingmodule/range/rangepublic/Database.java
+++ b/src/main/java/dk/sdu/se_f22/sortingmodule/range/rangepublic/Database.java
@@ -63,8 +63,8 @@ public class Database implements DatabaseInterface {
                     statement.setString(1, filter.getName());
                     statement.setString(2, filter.getDescription());
                     statement.setString(3, filter.getProductAttribute());
-                    statement.setTimestamp(4, new Timestamp(filter.getDbMinInstant().toEpochMilli()), cal);
-                    statement.setTimestamp(5, new Timestamp(filter.getDbMaxInstant().toEpochMilli()), cal);
+                    statement.setTimestamp(4, Timestamp.from(filter.getDbMinInstant()), cal);
+                    statement.setTimestamp(5, Timestamp.from(filter.getDbMaxInstant()), cal);
                 }
                 default -> throw new InvalidFilterTypeException("Didn't match any of our builtin RangeFilter types.");
             }
@@ -232,8 +232,8 @@ public class Database implements DatabaseInterface {
                     statement.setString(1, filter.getName());
                     statement.setString(2, filter.getDescription());
                     statement.setString(3, filter.getProductAttribute());
-                    statement.setTimestamp(4, new Timestamp(filter.getDbMinInstant().toEpochMilli()), cal);
-                    statement.setTimestamp(5, new Timestamp(filter.getDbMaxInstant().toEpochMilli()), cal);
+                    statement.setTimestamp(4, Timestamp.from(filter.getDbMinInstant()), cal);
+                    statement.setTimestamp(5, Timestamp.from(filter.getDbMaxInstant()), cal);
                     statement.setInt(6, filter.getId());
                 }
                 default -> throw new InvalidFilterTypeException("Didn't match any of our builtin RangeFilter types.");

--- a/src/main/java/dk/sdu/se_f22/sortingmodule/range/rangepublic/Database.java
+++ b/src/main/java/dk/sdu/se_f22/sortingmodule/range/rangepublic/Database.java
@@ -7,7 +7,9 @@ import dk.sdu.se_f22.sortingmodule.range.exceptions.UnknownFilterTypeException;
 
 import java.sql.*;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
+import java.util.TimeZone;
 
 public class Database implements DatabaseInterface {
     private final String[] queryAttributes = {"filterid", "name", "description", "productattribute", "min", "max"};
@@ -53,6 +55,7 @@ public class Database implements DatabaseInterface {
                     statement.setLong(5, filter.getDbMaxLong());
                 }
                 case TIME -> {
+                    Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
                     statement = connection.prepareStatement(
                             "INSERT INTO SortingRangeTimeView (name, description, productAttribute, min, max) VALUES (?, ?, ?, ?, ?)",
                             queryAttributes
@@ -60,8 +63,8 @@ public class Database implements DatabaseInterface {
                     statement.setString(1, filter.getName());
                     statement.setString(2, filter.getDescription());
                     statement.setString(3, filter.getProductAttribute());
-                    statement.setTimestamp(4, Timestamp.from(filter.getDbMinInstant()));
-                    statement.setTimestamp(5, Timestamp.from(filter.getDbMaxInstant()));
+                    statement.setTimestamp(4, new Timestamp(filter.getDbMinInstant().toEpochMilli()), cal);
+                    statement.setTimestamp(5, new Timestamp(filter.getDbMaxInstant().toEpochMilli()), cal);
                 }
                 default -> throw new InvalidFilterTypeException("Didn't match any of our builtin RangeFilter types.");
             }
@@ -156,13 +159,16 @@ public class Database implements DatabaseInterface {
     }
 
     private TimeFilter createTimeFilterFromResultset(ResultSet filterResultSet) throws SQLException {
+        // We need to force use of UTC for the testrunner
+        java.util.Calendar cal = Calendar.getInstance();
+        cal.setTimeZone(TimeZone.getTimeZone("UTC"));
         return new TimeFilter(
                 filterResultSet.getInt("FilterId"),
                 filterResultSet.getString("Name"),
                 filterResultSet.getString("Description"),
                 filterResultSet.getString("ProductAttribute"),
-                filterResultSet.getTimestamp("Min").toInstant(),
-                filterResultSet.getTimestamp("Max").toInstant()
+                filterResultSet.getTimestamp("Min", cal).toInstant(),
+                filterResultSet.getTimestamp("Max", cal).toInstant()
         );
     }
 
@@ -218,6 +224,7 @@ public class Database implements DatabaseInterface {
 
                 }
                 case TIME -> {
+                    Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
                     statement = connection.prepareStatement(
                             "UPDATE SortingRangeTimeView SET name=?, description=?, productAttribute=?, min=?, max=? WHERE (filterId = ?);",
                             new String[]{"filterid", "name", "description", "productattribute", "min", "max"}
@@ -225,8 +232,8 @@ public class Database implements DatabaseInterface {
                     statement.setString(1, filter.getName());
                     statement.setString(2, filter.getDescription());
                     statement.setString(3, filter.getProductAttribute());
-                    statement.setTimestamp(4, Timestamp.from(filter.getDbMinInstant()));
-                    statement.setTimestamp(5, Timestamp.from(filter.getDbMaxInstant()));
+                    statement.setTimestamp(4, new Timestamp(filter.getDbMinInstant().toEpochMilli()), cal);
+                    statement.setTimestamp(5, new Timestamp(filter.getDbMaxInstant().toEpochMilli()), cal);
                     statement.setInt(6, filter.getId());
                 }
                 default -> throw new InvalidFilterTypeException("Didn't match any of our builtin RangeFilter types.");

--- a/src/test/java/dk/sdu/se_f22/sortingmodule/range/Helpers.java
+++ b/src/test/java/dk/sdu/se_f22/sortingmodule/range/Helpers.java
@@ -26,7 +26,7 @@ public class Helpers {
     public static List<String> readFromCSV(String fileName) {
         List<String> out = new ArrayList<>();
       
-        try (Scanner scanner = new Scanner(new File("src/test/resources/dk/sdu/se_f22/SortingModule/Range/" + fileName))) {
+        try (Scanner scanner = new Scanner(new File("src/test/resources/dk/sdu/se_f22/sortingmodule/range/" + fileName))) {
             while (scanner.hasNextLine()) {
                 out.add(scanner.nextLine());
             }

--- a/src/test/java/dk/sdu/se_f22/sortingmodule/range/rangepublic/DatabaseTest.java
+++ b/src/test/java/dk/sdu/se_f22/sortingmodule/range/rangepublic/DatabaseTest.java
@@ -166,7 +166,7 @@ class DatabaseTest {
             Assertions.assertAll("Read all filters from database and check if the values match",
                     () -> Assertions.assertEquals(new DoubleFilter(1, "test name double", "test description", "price", 0, 10), result.get(0)),
                     () -> Assertions.assertEquals(new LongFilter(2, "test name ean", "test description for long filter", "ean", 2, 100), result.get(1)),
-                    () -> Assertions.assertEquals(new TimeFilter(3, "test name time", "test description for time filter", "expirationDate", Instant.parse("2018-11-30T15:35:24Z"), Instant.parse("2022-11-30T15:35:24Z")), result.get(2))
+                    () -> Assertions.assertEquals(new TimeFilter(3, "test name time", "test description for time filter", "expirationDate", Instant.parse("2018-11-30T16:35:24Z"), Instant.parse("2022-11-30T16:35:24Z")), result.get(2))
             );
         }
 

--- a/src/test/java/dk/sdu/se_f22/sortingmodule/range/rangepublic/RangeFilterCRUDTest.java
+++ b/src/test/java/dk/sdu/se_f22/sortingmodule/range/rangepublic/RangeFilterCRUDTest.java
@@ -547,7 +547,7 @@ public class RangeFilterCRUDTest {
             Assertions.assertAll("Read all filters from database and check if the values match",
                     () -> Assertions.assertEquals(new DoubleFilter(1, "test name double", "test description", "price", 0, 10), result.get(0)),
                     () -> Assertions.assertEquals(new LongFilter(2, "test name ean", "test description for long filter", "ean", 2, 100), result.get(1)),
-                    () -> Assertions.assertEquals(new TimeFilter(3, "test name time", "test description for time filter", "expirationDate", Instant.parse("2018-11-30T15:35:24Z"), Instant.parse("2022-11-30T15:35:24Z")), result.get(2))
+                    () -> Assertions.assertEquals(new TimeFilter(3, "test name time", "test description for time filter", "expirationDate", Instant.parse("2018-11-30T16:35:24Z"), Instant.parse("2022-11-30T16:35:24Z")), result.get(2))
             );
         }
 

--- a/src/test/resources/dk/sdu/se_f22/sortingmodule/range/rangepublic/TimeFilter.csv
+++ b/src/test/resources/dk/sdu/se_f22/sortingmodule/range/rangepublic/TimeFilter.csv
@@ -1,4 +1,4 @@
 id,name,description,productAtrribute,min,max
-3,test name time,test description for time filter,expirationDate,2018-11-30T15:35:24.00Z,2022-11-30T15:35:24.00Z
-6,test name time six,sechs test description for time filter,publishedDate,2011-11-30T18:35:24.00Z,2019-11-30T18:35:24.00Z
-7,test name time sieben,seven test description for time filter,someDate,2020-11-30T18:35:24.00Z,2030-11-30T18:35:24.00Z
+3,test name time,test description for time filter,expirationDate,2018-11-30T16:35:24.00Z,2022-11-30T16:35:24.00Z
+6,test name time six,sechs test description for time filter,publishedDate,2011-11-30T19:35:24.00Z,2019-11-30T19:35:24.00Z
+7,test name time sieben,seven test description for time filter,someDate,2020-11-30T19:35:24.00Z,2030-11-30T19:35:24.00Z

--- a/src/test/resources/dk/sdu/se_f22/sortingmodule/range/rangepublic/TimeFilterToCreate.csv
+++ b/src/test/resources/dk/sdu/se_f22/sortingmodule/range/rangepublic/TimeFilterToCreate.csv
@@ -1,2 +1,2 @@
 name,description,productAtrribute,min,max
-test name time create,test description for time filter,expirationDate,2018-11-30T15:35:24.00Z,2022-11-30T15:35:24.00Z
+test name time create,test description for time filter,expirationDate,2018-11-30T16:35:24.00Z,2022-11-30T16:35:24.00Z

--- a/src/test/resources/dk/sdu/se_f22/sortingmodule/range/rangepublic/TimeFilterToUpdate.csv
+++ b/src/test/resources/dk/sdu/se_f22/sortingmodule/range/rangepublic/TimeFilterToUpdate.csv
@@ -1,2 +1,2 @@
 id,name,description,productAtrribute,min,max,uMin,uMax
-10002,TestUpdateTimeName,TestUpdateTimeDescription,TestUpdateTimeAttribute,2020-11-30T18:35:24.00Z,2021-11-30T18:35:24.00Z,2022-11-30T18:35:24.00Z,2023-11-30T18:35:24.00Z
+10002,TestUpdateTimeName,TestUpdateTimeDescription,TestUpdateTimeAttribute,2020-11-30T19:35:24.00Z,2021-11-30T19:35:24.00Z,2022-11-30T19:35:24.00Z,2023-11-30T19:35:24.00Z


### PR DESCRIPTION
When running`testReadTimeFromRangeFilterDatabase` on a machine that doesn't use CET(Central European Time) as its timezone, the test fails. This is because the testdata assumes a UTC->CET conversion which can be seen since the testdata requires the time be set one hour before the time inserted in the migration files.

<img width="1188" alt="Screenshot 2022-05-16 at 20 10 05" src="https://user-images.githubusercontent.com/20731972/168656099-00fce092-c0bf-4b17-b808-3e9051096a58.png">

I think you have used TLD instead of TDD, and used your own code to validate the test data instead of the other way around. Anyway, I have fixed the code, so it always uses UTC and updated the test data, such the it matches what is inserted in the database.

I have also fixed I path in the helper, when reading a csv file, an incorrect casing was used for the path, that only worked on case insensitive systems.
