### PR TITLE
Added demo data, to make BIM1 tests pass

### DIFF
--- a/src/main/resources/dk/sdu/se_f22/sharedlibrary/db/migrations/6.2_testfix_brand.sql
+++ b/src/main/resources/dk/sdu/se_f22/sharedlibrary/db/migrations/6.2_testfix_brand.sql
@@ -1,0 +1,3 @@
+INSERT INTO brand (name, description, founded, headquarters) VALUES ('Demo', 'This is a demo brand', 'never', 'Odense, Denmark, The World');
+INSERT INTO producttype (type) VALUES ('Demo');
+INSERT INTO brandproducttypejunction (brandid, productid) VALUES (1,1);


### PR DESCRIPTION
This adds brand, producttype and brandproducttypejunction data to the database, to make tests pass